### PR TITLE
build and ci updates

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,11 +15,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.0
+          version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '>=1.23.0'
+          go-version: stable
           cache: true
       - name: Go Preflight Tests
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,8 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - darwin
+      - windows
     ldflags:
       - -X github.com/tjhop/ns1_exporter/internal/version.BuildDate={{ .CommitDate }}
       - -X github.com/tjhop/ns1_exporter/internal/version.Version={{ .Version }}
@@ -59,6 +61,8 @@ nfpms:
     scripts:
       preinstall: ./packaging/scripts/preinstall.sh
       postinstall: ./packaging/scripts/postinstall.sh
+universal_binaries:
+  - replace: true
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,23 +19,25 @@ builds:
 gomod:
   proxy: true
   mod: mod
-dockers:
-  # build latest and specific tag version images
-  - image_templates:
-      - "ghcr.io/tjhop/{{.ProjectName}}:{{ .Tag }}"
-      - "ghcr.io/tjhop/{{.ProjectName}}:latest"
-    goos: linux
-    goarch: amd64
-    use: docker
-    build_flag_templates:
-    - "--pull"
-    - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.title={{.ProjectName}}"
-    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
-    - "--label=org.opencontainers.image.source=https://github.com/tjhop/ns1_exporter"
-    - "--label=org.opencontainers.image.description='NS1 Prometheus Exporter and HTTP SD Provider'"
-    - "--label=org.opencontainers.image.licenses=Apache-2.0"
+dockers_v2:
+  - images:
+      - "ghcr.io/tjhop/{{.ProjectName}}"
+    tags:
+      - "{{.Version}}"
+      - "v{{.Version}}"
+      - "latest"
+    labels:
+      "org.opencontainers.image.description": "NS1 Prometheus Exporter and HTTP SD Provider"
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}"
+      "org.opencontainers.image.title": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.source": "{{.GitURL}}"
+      "org.opencontainers.image.licenses": "Apache-2.0"
+    platforms:
+      - linux/amd64
+      - linux/arm64
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,9 +58,6 @@ nfpms:
           mode: 0644
           owner: root
           group: root
-    scripts:
-      preinstall: ./packaging/scripts/preinstall.sh
-      postinstall: ./packaging/scripts/postinstall.sh
 universal_binaries:
   - replace: true
 changelog:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,9 @@ builds:
       - linux
       - darwin
       - windows
+    goarch:
+      - amd64
+      - arm64
     ldflags:
       - -X github.com/tjhop/ns1_exporter/internal/version.BuildDate={{ .CommitDate }}
       - -X github.com/tjhop/ns1_exporter/internal/version.Version={{ .Version }}

--- a/Makefile
+++ b/Makefile
@@ -4,45 +4,33 @@ GOMOD := ${GOCMD} mod
 RELEASE_CONTAINER_NAME := "ns1_exporter"
 GOLANGCILINT_CACHE := ${CURDIR}/.golangci-lint/build/cache
 
-## help:			print this help message
 .PHONY: help
-help: Makefile
-	# autogenerate help messages for comment lines with 2 `#`
-	@sed -n 's/^##//p' $<
+help: ## print this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-z0-9A-Z_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-## tidy:			tidy modules
-tidy:
+tidy: ## tidy modules
 	${GOMOD} tidy
 
-## fmt:			apply go code style formatter
-fmt:
+fmt: ## apply go code style formatter
 	${GOFMT} -x ./...
 
-## lint:			run linters
-lint:
+lint: ## run linters
 	golangci-lint run -v
 	nilaway ./...
 
-## binary:		build a binary
-binary: fmt tidy lint
+binary: fmt tidy lint ## build a binary
 	goreleaser build --clean --single-target --snapshot --output .
 
-## build:			alias for `binary`
-build: binary
+build: binary ## alias for `binary`
 
-## test: 			run tests
-test: fmt tidy lint
+test: fmt tidy lint ## run tests
 	go test -race -v ./...
 
-## container: 		build container image with binary
-container: binary
+container: binary ## build container image with binary
 	podman image build -t "${RELEASE_CONTAINER_NAME}:latest" .
 
-## image:			alias for `container`
-image: container
+image: container ## alias for `container`
 
-## podman:		alias for `container`
-podman: container
+podman: container ## alias for `container`
 
-## docker:		alias for `container`
-docker: container
+docker: container ## alias for `container`

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ fmt:
 
 ## lint:			run linters
 lint:
-	mkdir -p ${GOLANGCILINT_CACHE} || true
-	podman run --rm -v ${CURDIR}:/app -v ${GOLANGCILINT_CACHE}:/root/.cache -w /app docker.io/golangci/golangci-lint:latest golangci-lint run -v
+	golangci-lint run -v
 	nilaway ./...
 
 ## binary:		build a binary

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _NOTE_: Installing via this method will result in a build without embedded metad
 git clone https://github.com/tjhop/ns1_exporter.git
 cd ns1_exporter
 make build
-NS1_APIKEY="<api-token>" ./dist/ns1_exporter_linux_amd64_v1/ns1_exporter <flags>
+NS1_APIKEY="<api-token>" ./ns1_exporter <flags>
 ```
 
 ### Binary
@@ -114,7 +114,7 @@ An example Prometheus configuration file demonstrating HTTP SD can be found in [
 The available command line flags are documented in the help flag:
 
 ```shell
-~ -> ./dist/ns1_exporter_linux_amd64_v1/ns1_exporter -h
+~ -> ./ns1_exporter -h
 usage: ns1_exporter [<flags>]
 
 


### PR DESCRIPTION
- **build(make): have lint target use golangci-lint binary**
- **build(make): improve auto help generator**
- **ci: add darwin/windows builds**
- **build(goreleaser): remove pre/post package scripts that aren't used anymore**
- **ci: add arm64 support**
- **ci(goreleaser): convert to dockers_v2**
- **ci: bump actions, use latest golangci-lint**
- **ci: bump release actions, use stable go**
- **docs: update usage snippets to be distribution agnostic**
